### PR TITLE
Fix grep command in auto-tag workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -222,7 +222,7 @@ jobs:
     - name: Get version from manifest
       id: version
       run: |
-        VERSION=$(grep '\"version\"' manifest.json | cut -d'\"' -f4)
+        VERSION=$(grep '"version"' manifest.json | cut -d'"' -f4)
         echo "version=$VERSION" >> $GITHUB_OUTPUT
         echo "tag=v$VERSION" >> $GITHUB_OUTPUT
         echo "Current version in manifest: $VERSION"


### PR DESCRIPTION
- Remove escaped quotes that were causing cut delimiter error
- Use proper quote handling for grep and cut commands