### PR TITLE
Add workflow permissions for auto-tagging

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,10 @@
 name: CI/CD Pipeline
 
+permissions:
+  contents: write
+  actions: read
+  checks: read
+
 on:
   push:
     branches: [ main, develop* ]


### PR DESCRIPTION
- Grant contents:write permission to allow tag creation
- Add actions:read and checks:read for workflow execution
- This fixes the 403 permission error when pushing tags