### PR TITLE
Potential fix for code scanning alert no. 2: DOM text reinterpreted as HTML

### DIFF
--- a/options.js
+++ b/options.js
@@ -53,7 +53,15 @@ class OptionsManager {
         
         if (apiKey) {
             const tokenUrl = `https://trello.com/1/authorize?expiration=never&scope=read,write&response_type=token&name=Thunderbird%20Extension&key=${apiKey}`;
-            tokenUrlDiv.innerHTML = `<a href="${tokenUrl}" target="_blank">${tokenUrl}</a>`;
+            // Remove previous content
+            tokenUrlDiv.textContent = '';
+            // Create anchor safely
+            const a = document.createElement('a');
+            a.href = tokenUrl;
+            a.target = '_blank';
+            a.rel = 'noopener noreferrer';
+            a.textContent = tokenUrl;
+            tokenUrlDiv.appendChild(a);
             tokenUrlDisplay.style.display = 'block';
         } else {
             tokenUrlDisplay.style.display = 'none';


### PR DESCRIPTION
Potential fix for [https://github.com/zioalex/thunderbird-trello-integration/security/code-scanning/2](https://github.com/zioalex/thunderbird-trello-integration/security/code-scanning/2)

To fix the vulnerability, we must ensure that user-controlled data is not interpreted as HTML. The best way to do this is to avoid using `innerHTML` with interpolated untrusted data. Instead, we should create the anchor element using DOM methods, set its `href` and `textContent` properties, and append it to the container. This approach ensures that any meta-characters in the API key are properly escaped and cannot be used to inject HTML or JavaScript. The change should be made in the `updateTokenUrl` method in options.js, specifically replacing the code that sets `tokenUrlDiv.innerHTML`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
